### PR TITLE
integrate per-child lastSeen and begin category filtering

### DIFF
--- a/app/src/main/java/com/example/antibully/data/api/UserApiService.kt
+++ b/app/src/main/java/com/example/antibully/data/api/UserApiService.kt
@@ -12,6 +12,7 @@ data class MeResponse(
     val username: String?,
     val notificationsLastSeenAt: String?
 )
+data class ChildLastSeenDto(val discordId: String, val lastSeenAt: String)
 
 interface UserApiService {
     @GET("api/me")
@@ -25,4 +26,10 @@ interface UserApiService {
         @Header("Authorization") bearer: String,
         @Path("childId") childId: String
     ): Response<Unit>
+
+    @GET("api/me/notifications/last-seen")
+    suspend fun getNotificationsLastSeen(
+        @Header("Authorization") bearer: String
+    ): List<ChildLastSeenDto>
+
 }

--- a/app/src/main/java/com/example/antibully/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/example/antibully/data/repository/NotificationsRepository.kt
@@ -1,5 +1,6 @@
 package com.example.antibully.data.repository
 
+import com.example.antibully.data.api.ChildLastSeenDto
 import com.example.antibully.data.api.UserApiService
 import com.example.antibully.data.api.RetrofitClient
 import java.time.Instant
@@ -19,6 +20,9 @@ class NotificationsRepository(
         val res = api.markNotificationsReadForChild("Bearer $token", childId)
         if (!res.isSuccessful) error("markAllReadForChild failed ${res.code()}")
     }
+
+    suspend fun getNotificationsLastSeen(token: String): List<ChildLastSeenDto> =
+        api.getNotificationsLastSeen("Bearer $token")
 
     fun isoToMillis(iso: String): Long =
         Instant.parse(iso).toEpochMilli()

--- a/app/src/main/java/com/example/antibully/data/ui/feed/FeedFragment.kt
+++ b/app/src/main/java/com/example/antibully/data/ui/feed/FeedFragment.kt
@@ -125,6 +125,7 @@ class FeedFragment : Fragment() {
 
             FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()?.token?.let { token ->
                 viewModel.refreshLastSeen(token)
+                viewModel.loadLastSeenForChildren(token)
                 children.forEach { child -> viewModel.fetchAlerts(token, child.childId) }
             } ?: Log.e("FeedFragment", "Failed to get Firebase token")
 
@@ -148,14 +149,15 @@ class FeedFragment : Fragment() {
             viewModel.setSearchQuery(text?.toString().orEmpty())
         }
         binding.reasonToggleGroup.setOnCheckedChangeListener { _, checkedId ->
-            val reason = when (checkedId) {
+            val category: String? = when (checkedId) {
                 R.id.btnHarassment -> "Harassment"
-                R.id.btnExclusion -> "Social Exclusion"
+                R.id.btnExclusion  -> "Social Exclusion"
                 R.id.btnHateSpeech -> "Hate Speech"
-                R.id.btnCursing -> "Cursing"
-                else -> null
+                R.id.btnCursing    -> "Cursing"
+                R.id.btnAll        -> null
+                else               -> null
             }
-            Log.d("FeedFragment", "Reason filter: $reason")
+            viewModel.setCategory(category)
         }
     }
 


### PR DESCRIPTION
* Add support for fetching per-child notification lastSeen timestamps:
  - Introduce `UserApiService.getNotificationsLastSeen` to call GET /api/me/notifications/last-seen.
  - Add `NotificationsRepository.getNotificationsLastSeen` and helper to convert ISO timestamps to millis.
  - Extend `AlertViewModel` with `loadLastSeenForChildren` to populate `_lastSeenMillisByChild`.
  - Update `FeedFragment` to call `loadLastSeenForChildren()` when loading the feed.
* Start implementing category-based filtering:
  - Add `_selectedCategory` state and `categoryKeywords` mapping in `AlertViewModel`.
  - Connect filter chips in `FeedFragment` to `setCategory()`; current filtering logic still needs refinement.