### PR TITLE
resetting the filters after navigation

### DIFF
--- a/app/src/main/java/com/example/antibully/viewmodel/AlertViewModel.kt
+++ b/app/src/main/java/com/example/antibully/viewmodel/AlertViewModel.kt
@@ -54,8 +54,16 @@ class AlertViewModel(
         _selectedCategory.value = category
     }
 
+    val selectedCategory: StateFlow<String?> = _selectedCategory.asStateFlow()
     private val _imagesOnly = MutableStateFlow(false)
     fun setImagesOnly(enabled: Boolean) { _imagesOnly.value = enabled }
+
+    fun resetFilters() {
+        _selectedCategory.value = null
+        _imagesOnly.value = false
+    }
+
+    val imagesOnly: StateFlow<Boolean> = _imagesOnly.asStateFlow()
 
     val allAlerts: Flow<List<Alert>> = repository.allAlerts
 


### PR DESCRIPTION
issue fixed
when navigating from feed to different page and back to feed by default the app displays all alerts w/o any filters that were selected before.